### PR TITLE
changed http to https in node package source link

### DIFF
--- a/model/state.go
+++ b/model/state.go
@@ -70,7 +70,7 @@ func (c *Config) GetFullImageName() string {
 	if c.Backend == "docker" {
 		return _const.ImageNamePrefix + ":" + c.GetLatestImageTag()
 	} else {
-		return "http://github.com/mysteriumnetwork/node/"
+		return "https://github.com/mysteriumnetwork/node/"
 	}
 }
 


### PR DESCRIPTION
## Changed http to https in node package source link.
### In detail:
Changed the link to the package source thats shown to the user in the "Node info" section of the Launcher when running the node using the native backend without docker.

"http://github.com/mysteriumnetwork/node/" => "https://github.com/mysteriumnetwork/node/"

This change does not effect any other parts of the launcher apart from the ui.